### PR TITLE
Feature #6/judge dockerfile

### DIFF
--- a/Judge/Docker/Dockerfile_Judge
+++ b/Judge/Docker/Dockerfile_Judge
@@ -1,0 +1,25 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt upgrade -y && apt install -y \
+    git \
+    gcc \
+    bc \
+    bubblewrap \
+    make \
+    time \
+    tzdata
+
+WORKDIR /
+
+ENV TZ=America/Sao_Paulo
+RUN ln -sf /usr/share/zoneinfo/America/Sao_Paulo /etc/localtime
+
+RUN git clone https://github.com/NimbusJudgeOrganization/JUDGE_MicroJudge.git
+
+WORKDIR /JUDGE_MicroJudge/Judge
+
+# RUN ./calibreitor.sh fatorial # needs usern remap
+
+# ENTRYPOINT ["/bin/bash", "-c", "build-and-test.sh", "c", "jorge.c", "fatorial"] # needs usern remap

--- a/Judge/Docker/Dockerfile_Judge
+++ b/Judge/Docker/Dockerfile_Judge
@@ -20,6 +20,4 @@ RUN git clone https://github.com/NimbusJudgeOrganization/JUDGE_MicroJudge.git
 
 WORKDIR /JUDGE_MicroJudge/Judge
 
-# RUN ./calibreitor.sh fatorial # needs usern remap
-
-# ENTRYPOINT ["/bin/bash", "-c", "build-and-test.sh", "c", "jorge.c", "fatorial"] # needs usern remap
+# needs usern remap

--- a/Judge/Docker/README.md
+++ b/Judge/Docker/README.md
@@ -1,10 +1,28 @@
-# Run Container
+# Run container automatically with compose
 ## Build and run container:
 ```sh
 docker compose up
 ```
+>Note: The entrypoint for the Docker container, defining the sequence of commands to be executed, is configured in the **docker-compose.yaml** file as follows:
+```yaml
+entrypoint: ["/bin/bash", "-c", "./calibreitor.sh fatorial && ./build-and-test.sh c jorge.c fatorial"]
+```
+>This configuration specifies that when the container starts, it will **execute calibreitor.sh with the fatorial argument** followed by **build-and-test.sh with the specified arguments (c jorge.c fatorial)**. Adjust the entrypoint command in the docker-compose.yml file as needed for **your specific use case**.
 
-## In other terminal, enter in container
+# Running Manually(for tests)
+
+## Build Image
+
+```sh
+docker image build -t judge_image -f Dockerfile_Judge .
+```
+
+## Access Container Terminal
+
+```sh
+docker container run -it --privileged judge_image /bin/bash
+```
+
 ```sh
 docker container exec -it judge /bin/bash
 ```

--- a/Judge/Docker/README.md
+++ b/Judge/Docker/README.md
@@ -1,0 +1,20 @@
+# Run Container
+## Build and run container:
+    ```sh
+    docker compose up
+    ```
+
+## In other terminal, enter in container
+    ```sh
+    docker container exec -it judge /bin/bash
+    ```
+# Docker Runnning Test Example: <span style="color:red"> * -> manual while remap userns are not configured*</span>
+## Calibreitor 
+```sh
+./calibreitor.sh fatorial
+```
+
+## Build And Test
+```sh
+./build-and-test.sh c jorge.c fatorial
+```

--- a/Judge/Docker/README.md
+++ b/Judge/Docker/README.md
@@ -1,20 +1,20 @@
 # Run Container
 ## Build and run container:
-    ```
-    docker compose up
-    ```
+```sh
+docker compose up
+```
 
 ## In other terminal, enter in container
-    ```
-    docker container exec -it judge /bin/bash
-    ```
+```sh
+docker container exec -it judge /bin/bash
+```
 # Docker Runnning Test Example: <span style="color:red"> * -> manual while remap userns are not configured*</span>
 ## Calibreitor 
-```
+```sh
 ./calibreitor.sh fatorial
 ```
 
 ## Build And Test
-```
+```sh
 ./build-and-test.sh c jorge.c fatorial
 ```

--- a/Judge/Docker/README.md
+++ b/Judge/Docker/README.md
@@ -1,20 +1,20 @@
 # Run Container
 ## Build and run container:
-    ```sh
+    ```
     docker compose up
     ```
 
 ## In other terminal, enter in container
-    ```sh
+    ```
     docker container exec -it judge /bin/bash
     ```
 # Docker Runnning Test Example: <span style="color:red"> * -> manual while remap userns are not configured*</span>
 ## Calibreitor 
-```sh
+```
 ./calibreitor.sh fatorial
 ```
 
 ## Build And Test
-```sh
+```
 ./build-and-test.sh c jorge.c fatorial
 ```

--- a/Judge/Docker/docker-compose.yaml
+++ b/Judge/Docker/docker-compose.yaml
@@ -1,14 +1,15 @@
-version: '3.8'
-
 services:
   judge:
     image: judge_image
     container_name: judge
     platform: linux/amd64
-    stdin_open: true # until the usern remap works
+    #stdin_open: true # until the usern remap works
     privileged: true
-    tty: true
+    #tty: true
     command: /bin/bash
+    ports:
+      - "8280:8280"
     build:
       context: .
       dockerfile: Dockerfile_Judge
+    entrypoint: ["/bin/bash", "-c", "./calibreitor.sh fatorial && ./build-and-test.sh c jorge.c fatorial"]

--- a/Judge/Docker/docker-compose.yaml
+++ b/Judge/Docker/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  judge:
+    image: judge_image
+    container_name: judge
+    platform: linux/amd64
+    stdin_open: true # until the usern remap works
+    privileged: true
+    tty: true
+    command: /bin/bash
+    build:
+      context: .
+      dockerfile: Dockerfile_Judge


### PR DESCRIPTION
## Related Issue
Resolves #6 

## Description
A container was created to facilitate testing of the calibreitor.sh program from the cd-moj platform. This container simplifies testing and can be seamlessly integrated into cloud architectures.

## Proposed Changes
- Judge/Docker
- docker-compose
- Dockerfile_Judge

## Tests Performed
- Instructions for testing the application are in the readme found at Judge/README.md

## Screenshots
![Captura de tela de 2024-04-25 16-21-34](https://github.com/NimbusJudgeOrganization/Nimbus-Judge-Organization/assets/104279524/ec6bc243-fc80-484a-b1da-f9172df86a1f)


## Review Checklist

- [x] Are the changes adequately documented?
- [x] Have tests been executed and passed successfully?
- [x] Are the changes aligned with the related issue?

## Additional Notes
It is recommended that changes be made in such a way that the container accepts as input programs that can be judged